### PR TITLE
feat!(request-hook): add new request hook

### DIFF
--- a/examples/movies/src/app.tsx
+++ b/examples/movies/src/app.tsx
@@ -3,14 +3,7 @@ import { useRequest } from 'react-rest-request';
 import { MoviesEndpoint, MoviesResponse } from './endpoint';
 
 export default function App() {
-    const [movies, { data, loading }] = useRequest<MoviesResponse>(MoviesEndpoint);
-
-    React.useEffect(
-        () => {
-            movies();
-        },
-        [movies]
-    );
+    const { data, loading } = useRequest<MoviesResponse>(MoviesEndpoint);
 
     return !data ? (
         <div>{ loading ? 'Loading...' : 'Something went wrong' }</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-rest-request",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from './endpoint';
 export * from './client';
 export * from './client-hook';
+export * from './lazy-request-hook';
 export * from './request-hook';
 export * from './request-context';
 export * from './reducer';

--- a/src/lazy-request-hook.ts
+++ b/src/lazy-request-hook.ts
@@ -1,0 +1,115 @@
+import React from 'react';
+import invariant from 'tiny-invariant';
+import isEqual from 'lodash.isequal';
+import { useClient } from './client-hook';
+import { Endpoint } from './endpoint';
+import { PublicRequestState, RequestAction, requestReducer, RequestState } from './reducer';
+import { useRequestContext } from './request-context';
+
+export type LazyRequestConfig<R, V, P = void> = Readonly<{
+    variables?: V;
+    params?: P;
+    headers?: Record<string, string>;
+    onComplete?: (data: R) => unknown;
+}>
+
+export type LazyRequestHandlerConfig<R, V, P> = Readonly<
+    LazyRequestConfig<R, V, P>
+    & { force?: boolean }
+>
+
+export type RequestHandler<R, V, P> = (config?: LazyRequestHandlerConfig<R, V, P>) => Promise<R | null>;
+
+export function useLazyRequest<R = Record<string, any>, V = Record<string, any>, P = void>(
+    endpoint: Endpoint<P>,
+    config?: LazyRequestConfig<R, V, P>,
+): [RequestHandler<R, V, P>, PublicRequestState<R>] {
+    const [client] = useClient();
+    const { defaultHeaders } = useRequestContext();
+    const [state, dispatch] = React.useReducer<React.Reducer<RequestState<R>, RequestAction<R>>>(
+        requestReducer,
+        {
+            data: null,
+            loading: false,
+            isCalled: false,
+        }
+    );
+
+    const handler = React.useCallback(
+        (handlerConfig?: LazyRequestHandlerConfig<R, V, P>) => {
+            if (state?.loading) {
+                return Promise.resolve(null);
+            }
+
+            let params: P | undefined;
+            let endpointUrl: string;
+            let isSameRequest = true;
+            if (typeof endpoint.url === 'function') {
+                params = handlerConfig?.params ?? config?.params;
+                invariant(params, 'Endpoind required params');
+
+                endpointUrl = endpoint.url(params);
+
+                isSameRequest = !!state?.prevParams && isEqual(state.prevParams, params);
+            } else {
+                endpointUrl = endpoint.url;
+            }
+
+            const variables = {
+                ...config?.variables,
+                ...handlerConfig?.variables,
+            };
+
+            const headers = {
+                ...defaultHeaders,
+                ...endpoint.headers,
+                ...config?.headers,
+                ...handlerConfig?.headers,
+            };
+
+            if (
+                isSameRequest
+                && state?.prevVariables && isEqual(state.prevVariables, variables)
+                && state?.prevHeaders && isEqual(state.prevHeaders, headers)
+                && !handlerConfig?.force
+            ) {
+                return Promise.resolve(state.data);
+            }
+
+            const onComplete = config?.onComplete ?? handlerConfig?.onComplete;
+
+            dispatch({ type: 'call', headers, variables, params });
+
+            return client
+                .request<R>({
+                    ...endpoint,
+                    url: endpointUrl,
+                    headers,
+                    variables,
+                })
+                .then(
+                    (response) => {
+                        dispatch({ type: 'success', response });
+                        if (typeof onComplete === 'function') {
+                            onComplete(response.data);
+                        }
+                        return response.data;
+                    },
+                    (response) => {
+                        dispatch({ type: 'failure', response });
+                        throw response;
+                    }
+                );
+        },
+        [state, config, client, endpoint, defaultHeaders]
+    );
+
+    return [
+        handler,
+        {
+            data: state.data,
+            loading: state.loading,
+            isCalled: state.isCalled,
+        },
+    ];
+}

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -9,6 +9,8 @@ export type RequestState<R> = Readonly<{
     prevParams?: Record<string, any>
 }>
 
+export type PublicRequestState<R> = Pick<RequestState<R>, 'data' | 'loading' | 'isCalled'>;
+
 export type RequestAction<R> =
     | { type: 'call', headers: Record<string, string>, variables: Record<string, any>, params?: Record<string, any> }
     | { type: 'success', response: ClientResponse<R> }


### PR DESCRIPTION
This hook works only for endpoint with GET method.

* refac!(request-hook): add lazy prefix to request hook

BREAKING CHANGES: you need to rename all `useRequest` hooks to
`useLazyRequest`

* refac!(request-hook): add public request state

BREAKING CHANGES: User shouldn't see previous headers, variables and params.
It's only for hooks so it doesn't call request again. If you use these
state you should to remove it from your code.

* chore: update example

Closes #5